### PR TITLE
Better existing attributeSet ID check

### DIFF
--- a/app/code/community/RetailOps/Api/Model/Catalog/Adapter/Attribute.php
+++ b/app/code/community/RetailOps/Api/Model/Catalog/Adapter/Attribute.php
@@ -258,8 +258,8 @@ class RetailOps_Api_Model_Catalog_Adapter_Attribute extends RetailOps_Api_Model_
     {
         if (!empty($data['attribute_set'])) {
             $attributeSet = $data['attribute_set'];
-            $attributeSetId = $this->_getAttributeSetIdByName($attributeSet);
-            if ($attributeSetId === false) {
+            $attributeSetId = (int)$this->_getAttributeSetIdByName($attributeSet);
+            if ($attributeSetId === 0) {
                 try {
                     $attributeSetId = $this->_createAttributeSet($attributeSet, $data['sku']);
                 } catch (Mage_Api_Exception $e) {


### PR DESCRIPTION
To prevent the error: 'Error Attribute set with the "default" name already exists.' as the data coming across could potentially be a string value and not an integer.  Cast the value to an integer and use 0 instead of false in the bit wise comparison.
