### PR TITLE
Bug fixes, modman, composer

### DIFF
--- a/app/code/community/RetailOps/Api/Helper/Data.php
+++ b/app/code/community/RetailOps/Api/Helper/Data.php
@@ -35,6 +35,8 @@ class RetailOps_Api_Helper_Data extends Mage_Api_Helper_Data
 
     const DEFAULT_LIMIT = 10;
 
+    const XML_CONFIG_DEFAULT_GROUP      = 'catalog';
+
     public function getRetOpsStatuses()
     {
         return array(
@@ -95,6 +97,10 @@ class RetailOps_Api_Helper_Data extends Mage_Api_Helper_Data
      */
     public function getConfig($path)
     {
+        if (strpos($path, '/') === false) {
+            $path = self::XML_CONFIG_DEFAULT_GROUP . '/' . $path;
+        }
+        
         return Mage::getStoreConfig('retailops_settings/' . $path);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name"          : "gudTECH/retailops_magento",
+    "type"          : "magento-module",
+    "license"       : "MIT",
+    "homepage"      : "http://www.retailops.com/",
+    "description"   : "The Ultimate Tools for Retail",
+    "authors": [
+        {
+            "name"  : "RetailOps",
+            "email" : "info@retailops.com"
+        }
+    ],
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,4 @@
+app/etc/modules/RetailOps_Api.xml                   app/etc/modules/RetailOps_Api.xml
+app/code/community/RetailOps/Api                    app/code/community/RetailOps/Api
+app/design/adminhtml/default/default/layout/*       app/design/adminhtml/default/default/layout/
+app/design/adminhtml/default/default/template/*     app/design/adminhtml/default/default/template/


### PR DESCRIPTION
- Bug fix in helper config getter, default to catalog group
- Add composer.json
- Add modman

---

The bug fix resolved an issue for us where the `media_processing_products_limit` value was ignored during catalog product image processing. This was caused by the omission of a system configuration group name. I added a fallback in the helper to preserve existing entries elsewhere in code.
