### PR TITLE
Fix setting of store-specific multi-select attribute values

### DIFF
--- a/app/code/community/RetailOps/Api/Model/Catalog/Adapter/Default.php
+++ b/app/code/community/RetailOps/Api/Model/Catalog/Adapter/Default.php
@@ -98,7 +98,8 @@ class RetailOps_Api_Model_Catalog_Adapter_Default extends RetailOps_Api_Model_Ca
         try {
             foreach($this->_storeAttributeValues as $store_id => $attributeValues) {
                 foreach($attributeValues as $code => $value) {
-                    $product->addAttributeUpdate($code, $value, $store_id);
+                    $product->addAttributeUpdate(
+                        $code, is_array($value) ? implode(",", $value) : $value, $store_id);
                 }
             }
         } catch (Mage_Core_Exception $e) {


### PR DESCRIPTION
The setting of store-specific multi-select attribute values was not working.  This was because the `addAttributeUpdate` method has no effect if the value is an array.  To be able to set multiple values for multi-value attributes, the value has to be represented as a comma-delimited string.