### PR TITLE
Engage CircleCI (with dummy test)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/php:7.3.6
+    steps:
+      - checkout
+      - run:
+          name: "Install Dependencies"
+          command: |
+            wget -O phpunit https://phar.phpunit.de/phpunit-8.phar
+            chmod +x phpunit
+            # TODO: Actually install Magento.
+      - run:
+          name: "Run Test Suite"
+          command: |
+            ./phpunit -c phpunit.xml

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit>
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+final class BasicTest extends TestCase
+{
+    public function testTrueIsTrue(): void
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Establish enough of a CircleCI scaffolding to run dummy tests.

More work remains to be done if we are to install Magento in CI and actually run real tests, but this is a start.